### PR TITLE
Add Host updating and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# nerd-blame-bot
-Bot that pings you and calls you a nerd when you enter a voice chat.
+# among-us-status-update
+
+This is a bot that stores a list of hosts on connected servers. When a user types `!among hosts` it will respond with a list of users on your server that are hosting a round of Among Us and are also in voice chat.

--- a/index.js
+++ b/index.js
@@ -56,6 +56,6 @@ client.on('presenceUpdate', (oldPresence, newPresence) => {
     if (newPresence?.user?.bot) {
         return false
     }
-
+    
     PresenceSwitcher(oldPresence, newPresence, store)
 })

--- a/src/commands/hosts.js
+++ b/src/commands/hosts.js
@@ -1,4 +1,4 @@
-import { getHosts } from '../presences/among-us.js'
+import { getHostStrings } from '../presences/among-us.js'
 
 export default {
     name: 'hosts',
@@ -6,7 +6,7 @@ export default {
         'Displays a list of the players in the Discord server hosting a lobby of Among Us',
     args: false,
     execute: (message, store, _args) => {
-        const output = getHosts(message, store).filter((value) => value)
+        const output = getHostStrings(message, store).filter((value) => value)
 
         if (output.length > 0) {
             return message.channel.send(output)

--- a/src/store/hostsSlice.js
+++ b/src/store/hostsSlice.js
@@ -13,17 +13,22 @@ const hostsSlice = createSlice({
         hostRemoved: (state, action) => {
             hostsAdapter.removeOne(state, action.payload.id)
         },
+        hostUpdated: (state, action) => {
+            hostsAdapter.updateOne(state, action.payload)
+        },
     },
 })
 
-const hostsInGuild = (state, guildId) =>
-    hostsSelector.selectAll(state).filter((host) => host.guildId === guildId)
+const getHosts = (state) => hostsSelector.selectAll(state)
+const getHostById = (state, id) => hostsSelector.selectById(state, id)
 
-const { hostAdded, hostRemoved } = hostsSlice.actions
+const { hostAdded, hostRemoved, hostUpdated } = hostsSlice.actions
 
 export {
     hostsSlice,
     hostAdded,
     hostRemoved,
-    hostsInGuild,
+    hostUpdated,
+    getHosts,
+    getHostById,
 }


### PR DESCRIPTION
Because we receive updates from Guilds individually when a user begins to host, I've changed the `host` object to instead store an array of guild IDs that its available in. I've also temporarily updated the readme and will fix it up later.