### PR TITLE
Implement Clear command, update the list, remove store references

### DIFF
--- a/src/command-handler.js
+++ b/src/command-handler.js
@@ -3,11 +3,13 @@ import { client } from './boot.js'
 
 const fallback = (message) => {
     message.reply(
-        'Known commands currently:\n> `!among hosts` - Display users in your server hosting a lobby of Among Us on voice chat.'
+        `Known commands currently:
+        > \`!among hosts\` - Display users in your server hosting a lobby of Among Us on voice chat.
+        > \`!among clear\` - Clear hosts in your server from appearing in your list`
     )
 }
 
-export const CommandHandler = (message, store) => {
+export const CommandHandler = (message) => {
     const { prefix } = config
 
     const args = message.content.slice(prefix.length).trim().split(/ +/)
@@ -34,7 +36,7 @@ export const CommandHandler = (message, store) => {
 
             return message.channel.sendreply()
         }
-        command.execute(message, store, args)
+        command.execute(message, args)
     } catch (error) {
         console.error(error)
         message.reply('There was an error trying to execute that command!')

--- a/src/commands/clear.js
+++ b/src/commands/clear.js
@@ -1,0 +1,40 @@
+import { clearHosts, getHosts, updateHosts } from '../store/hostsSlice.js'
+import store from '../store/store.js'
+
+export default {
+    name: 'clear',
+    description:
+        'Displays a list of the players in the Discord server hosting a lobby of Among Us',
+    args: false,
+    execute: (message, _args) => {
+        message.reply('Clearing hosts from this Server!')
+
+        clearGuildFromHosts(message.guild.id)
+    },
+}
+
+const clearGuildFromHosts = (guildId) => {
+    const hosts = getHosts(store.getState())
+        .filter((host) => host.guilds.includes(guildId))
+        .map((host) => {
+            const guilds = host.guilds.filter((element) => element !== guildId)
+            return {
+                id: host.id,
+                changes: { guilds },
+            }
+        })
+
+    const removableHosts = hosts
+        .filter((host) => host.changes.guilds.length === 0)
+        .map((host) => host.id)
+
+    const updateableHosts = hosts.filter(
+        (host) => host.changes.guilds.length > 0
+    )
+
+    store.dispatch(updateHosts(updateableHosts))
+
+    if (removableHosts.length > 0) {
+        store.dispatch(clearHosts(removableHosts))
+    }
+}

--- a/src/commands/hosts.js
+++ b/src/commands/hosts.js
@@ -5,8 +5,8 @@ export default {
     description:
         'Displays a list of the players in the Discord server hosting a lobby of Among Us',
     args: false,
-    execute: (message, store, _args) => {
-        const output = getHostStrings(message, store).filter((value) => value)
+    execute: (message, _args) => {
+        const output = getHostStrings(message).filter((value) => value)
 
         if (output.length > 0) {
             return message.channel.send(output)

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import { bootClient } from './boot.js'
 import { CommandHandler } from './command-handler.js'
 import { PresenceSwitcher } from './presence-switcher.js'
-import store from './store/store.js'
 
 const client = bootClient()
 
@@ -10,12 +9,12 @@ client.on('ready', () => {
     client.user.setActivity('!among hosts')
 })
 
-client.on('message', (message) => CommandHandler(message, store))
+client.on('message', (message) => CommandHandler(message))
 
 client.on('presenceUpdate', (oldPresence, newPresence) => {
     if (newPresence?.user?.bot) {
         return false
     }
 
-    PresenceSwitcher(oldPresence, newPresence, store)
+    PresenceSwitcher(oldPresence, newPresence)
 })

--- a/src/presence-switcher.js
+++ b/src/presence-switcher.js
@@ -1,7 +1,7 @@
 import amongUsPresence from './presences/among-us.js'
 
-export const PresenceSwitcher = (oldPresence, newPresence, store) => {
+export const PresenceSwitcher = (oldPresence, newPresence) => {
     if (amongUsPresence.requirementsMatch(oldPresence, newPresence)) {
-        amongUsPresence.execute(oldPresence, newPresence, store)
+        amongUsPresence.execute(oldPresence, newPresence)
     }
 }

--- a/src/store/hostsSlice.js
+++ b/src/store/hostsSlice.js
@@ -16,13 +16,25 @@ const hostsSlice = createSlice({
         hostUpdated: (state, action) => {
             hostsAdapter.updateOne(state, action.payload)
         },
+        updateHosts: (state, action) => {
+            hostsAdapter.updateMany(state, action.payload)
+        },
+        clearHosts: (state, action) => {
+            hostsAdapter.removeMany(state, action.payload)
+        },
     },
 })
 
 const getHosts = (state) => hostsSelector.selectAll(state)
 const getHostById = (state, id) => hostsSelector.selectById(state, id)
 
-const { hostAdded, hostRemoved, hostUpdated } = hostsSlice.actions
+const {
+    hostAdded,
+    hostRemoved,
+    hostUpdated,
+    clearHosts,
+    updateHosts,
+} = hostsSlice.actions
 
 export {
     hostsSlice,
@@ -31,4 +43,6 @@ export {
     hostUpdated,
     getHosts,
     getHostById,
+    clearHosts,
+    updateHosts,
 }


### PR DESCRIPTION
Just in case a server needed to drop hosts, I've added the `clear` command to clear the server from any host lists, if the host's guild list is then empty, it drops the host from the records.

I also removed the passing of the Store reference due to being able to import the reference from the Store file.